### PR TITLE
Accessing assets by extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ SwigWebpackPlugin.prototype.apply = function(compiler) {
 		var context = this.context;
 
 		if (self.options.watch) {
-			var watchFiles = glob.sync(self.options.watch, {});
+			var watchFiles = glob.sync(path.join(context, self.options.watch), {});
 			if(watchFiles.length > 0) {
 				watchFiles.forEach(function(file) {
-					compiler.fileDependencies.push(path.join(context, file));
+					compiler.fileDependencies.push(file);
 				});
 				watchTemplate = false;
 			} else {
@@ -54,7 +54,7 @@ SwigWebpackPlugin.prototype.apply = function(compiler) {
 			if (files.length > 0) {
 				files.forEach(function(template) {
 					if(watchTemplate) {
-						compiler.fileDependencies.push(path.join(context, template));
+						compiler.fileDependencies.push(template);
 					}
 					var data = fs.readFileSync(template, 'utf8');
 					if (data) {

--- a/index.js
+++ b/index.js
@@ -108,20 +108,28 @@ SwigWebpackPlugin.prototype.htmlFormatter = function(options, html) {
 };
 
 SwigWebpackPlugin.prototype.swigWebpackPluginAssets = function(compiler, webpackStatsJson) {
-	var assets = {};
+	var assets = {
+		extensions: {}
+	};
+
 	for (var chunk in webpackStatsJson.assetsByChunkName) {
-		var chunkValue = webpackStatsJson.assetsByChunkName[chunk];
+		var chunkFiles = [].concat(webpackStatsJson.assetsByChunkName[chunk])
+			.map(function (fileName) {
+				if (compiler.options.output.publicPath) {
+					return compiler.options.output.publicPath + fileName;
+				}
 
-		// Webpack outputs an array for each chunk when using sourcemaps
-		if (chunkValue instanceof Array) {
-			// Is the main bundle always the first element?
-			chunkValue = chunkValue[0];
-		}
+				return fileName;
+			});
 
-		if (compiler.options.output.publicPath) {
-			chunkValue = compiler.options.output.publicPath + chunkValue;
-		}
-		assets[chunk] = chunkValue;
+		assets[chunk] = chunkFiles[0];
+
+		chunkFiles.forEach(function (chunkFile) {
+			var ext = chunkFile.split('.').pop();
+
+			assets.extensions[ext] = assets.extensions[ext] || [];
+			assets.extensions[ext].push(chunkFile);
+		});
 	}
 
 	return assets;


### PR DESCRIPTION
I needed a way to access .css files from the assets object.

I think this is a relatively elegant solution for it without breaking the original functionality.

```
{% for file in swigWebpackPlugin.assets.extensions.css %}
    <link href="{{file}}" rel="stylesheet" />
{% endfor %}`

{% for file in swigWebpackPlugin.assets.extensions.js %}
    <script type="text/javascript" src="{{file}}"></script>
{% endfor %}
```
